### PR TITLE
Subtitles and Disabling ToC

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ npx mr-pdf --initialDocsURL="https://example.com" --paginationSelector="li > a"
 
 - `--pdfFormat`:            pdf format ex: `--pdfFormat="A3"`. Please check this link for available formats [Puppeteer document](https://pptr.dev/#?product=Puppeteer&version=v5.2.1&show=api-pagepdfoptions)
 
+- `--disableTOC`: Optional toggle to show the table of contents or not. 
+
+- `coverTitle`: Title for the PDF cover.
+
+- `coverSub`: Subtitle the for PDF cover.
+
 
 ## 🎨 Examples and Demo PDF
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npx mr-pdf --initialDocsURL="https://example.com" --paginationSelector="li > a"
 
 - `coverTitle`: Title for the PDF cover.
 
-- `coverSub`: Subtitle the for PDF cover.
+- `coverSub`: Subtitle the for PDF cover. Add \<br/> tags for multiple lines.
 
 
 ## 🎨 Examples and Demo PDF

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -45,6 +45,7 @@ program
   .option('--coverTitle <title>', 'title for PDF cover')
   .option('--coverImage <src>', 'image for PDF cover. *.svg file not working!')
   .option('--disableTOC', 'disable table of contents')
+  .option('--coverSub <subtitle>', 'subtitle for PDF cover')
   .action((options: generatePDFOptions) => {
     generatePDF(options)
       .then(() => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,6 +44,7 @@ program
   .option('--pdfFormat <format>', 'pdf format ex: A3, A4...')
   .option('--coverTitle <title>', 'title for PDF cover')
   .option('--coverImage <src>', 'image for PDF cover. *.svg file not working!')
+  .option('--disableTOC', 'disable table of contents')
   .action((options: generatePDFOptions) => {
     generatePDF(options)
       .then(() => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,6 +15,7 @@ export interface generatePDFOptions {
   puppeteerArgs: Array<string>;
   coverTitle: string;
   coverImage: string;
+  disableTOC: boolean;
 }
 
 export async function generatePDF({
@@ -30,6 +31,7 @@ export async function generatePDF({
   puppeteerArgs,
   coverTitle,
   coverImage,
+  disableTOC,
 }: generatePDFOptions): Promise<void> {
   const browser = await puppeteer.launch({ args: puppeteerArgs });
   const page = await browser.newPage();
@@ -130,7 +132,7 @@ export async function generatePDF({
 
   // Restructuring the html of a document
   await page.evaluate(
-    ({ coverHTML, tocHTML, modifiedContentHTML }) => {
+    ({ coverHTML, tocHTML, modifiedContentHTML, disableTOC }) => {
       // Empty body content
       const body = document.body;
       body.innerHTML = '';
@@ -139,12 +141,12 @@ export async function generatePDF({
       body.innerHTML += coverHTML;
 
       // Add toc
-      body.innerHTML += tocHTML;
+      if (!disableTOC) body.innerHTML += tocHTML;
 
       // Add body content
       body.innerHTML += modifiedContentHTML;
     },
-    { coverHTML, tocHTML, modifiedContentHTML },
+    { coverHTML, tocHTML, modifiedContentHTML, disableTOC },
   );
 
   // Remove unnecessary HTML by using excludeSelectors

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,6 +16,7 @@ export interface generatePDFOptions {
   coverTitle: string;
   coverImage: string;
   disableTOC: boolean;
+  coverSub: string;
 }
 
 export async function generatePDF({
@@ -32,6 +33,7 @@ export async function generatePDF({
   coverTitle,
   coverImage,
   disableTOC,
+  coverSub,
 }: generatePDFOptions): Promise<void> {
   const browser = await puppeteer.launch({ args: puppeteerArgs });
   const page = await browser.newPage();
@@ -114,10 +116,12 @@ export async function generatePDF({
       justify-content: center;
       align-items: center;
       height: 100vh;
-      page-break-after: always;
+      page-break-after: always;  
+      text-align: center;
     "
   >
-    <h1 class="cover-title">${coverTitle}</h1>
+    ${coverTitle ? `<h1>${coverTitle}</h1>` : ''}
+    ${coverSub ? `<h3>${coverSub}</h3>` : ''}
     <img
       class="cover-img"
       src="data:image/png;base64, ${imgBase64}"


### PR DESCRIPTION
Added two CLI options:
- --disableTOC
- --coverSub <subtitle>

The first is a boolean that disables the table of contents when present. The second allows you to pass a subtitle to the PDF #26 .

If you want a multi-line subtitle, simply add <br/> tags between lines are both the subtitle and title are just HTML injections.

I've added these to the README and tried to make my modifications as minimal as possible.