### PR TITLE
Update and Publish 1.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mr-pdf",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Generate pdf from document",
   "main": "lib/cli.js",
   "scripts": {


### PR DESCRIPTION
Fix https://github.com/kohheepeace/mr-pdf/issues/27

Publish yarn package from Linux of wsl to avoid windows' unexpected EOL(end of lines) are included in published build.

Though In this PR, there is only version changes in `package.json`, after this version published build is generated from Linux.

## Ref
- https://github.com/darkguy2008/parallelshell/issues/58
- https://github.com/npm/npm/issues/2097