### PR TITLE
add option to wait for document render

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,6 +46,7 @@ program
   .option('--coverImage <src>', 'image for PDF cover. *.svg file not working!')
   .option('--disableTOC', 'disable table of contents')
   .option('--coverSub <subtitle>', 'subtitle for PDF cover')
+  .option('--waitForRender <timeout>', 'wait for document render')
   .action((options: generatePDFOptions) => {
     generatePDF(options)
       .then(() => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,6 +17,7 @@ export interface generatePDFOptions {
   coverImage: string;
   disableTOC: boolean;
   coverSub: string;
+  waitForRender: number;
 }
 
 export async function generatePDF({
@@ -34,6 +35,7 @@ export async function generatePDF({
   coverImage,
   disableTOC,
   coverSub,
+  waitForRender,
 }: generatePDFOptions): Promise<void> {
   const browser = await puppeteer.launch({ args: puppeteerArgs });
   const page = await browser.newPage();
@@ -167,6 +169,11 @@ export async function generatePDF({
   // Add CSS to HTML
   if (cssStyle) {
     await page.addStyleTag({ content: cssStyle });
+  }
+
+  if (waitForRender) {
+    console.log('Rendering...');
+    await new Promise((r) => setTimeout(r, waitForRender));
   }
 
   await page.pdf({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,11 +49,18 @@ export async function generatePDF({
       console.log(chalk.cyan(`Retrieving html from ${nextPageURL}`));
       console.log();
 
-      // Go to the page specified by nextPageURL
-      await page.goto(`${nextPageURL}`, {
-        waitUntil: 'networkidle0',
-        timeout: 0,
-      });
+      if (waitForRender) {
+        await page.goto(`${nextPageURL}`);
+        console.log(chalk.green('Rendering...'));
+        await page.waitFor(waitForRender);
+      } else {
+        // Go to the page specified by nextPageURL
+        await page.goto(`${nextPageURL}`, {
+          waitUntil: 'networkidle0',
+          timeout: 0,
+        });
+      }
+
       // Get the HTML string of the content section.
       const html = await page.evaluate(
         ({ contentSelector }) => {
@@ -169,11 +176,6 @@ export async function generatePDF({
   // Add CSS to HTML
   if (cssStyle) {
     await page.addStyleTag({ content: cssStyle });
-  }
-
-  if (waitForRender) {
-    console.log('Rendering...');
-    await new Promise((r) => setTimeout(r, waitForRender));
   }
 
   await page.pdf({


### PR DESCRIPTION
Our app documentation is around 140 pdf pages with a lot of images. During a pdf generation using mr-pdf script I would encounter two problems:

1. Some large images not being rendered fully.
2. Any images past ~40th page would not get rendered in the document at all.

Seems we just need a bit of a timeout to let the script glue all the html content it downloads from the docusaurus pages.

I've added `--waitForRender` option that takes a `number` value of ms in case anyone encounters a similar problem. (I am sure this won't be necessary for lightweight docs that don't have too many images).

This fixes #28