### PR TITLE
Add support for puppeteer headers and footers

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ npx mr-pdf --initialDocURLs="https://v1.docusaurus.io/docs/en/installation" --pa
 | `--coverTitle`         | No       | Title for the PDF cover.                                                                                                                                                           |
 | `--coverImage`         | No       | `<src>` Image for PDF cover (does not support SVG)                                                                                                                                 |
 | `--coverSub`           | No       | Subtitle the for PDF cover. Add `<br/>` tags for multiple lines.                                                                                                                   |
-|                        |
+| `--headerTemplate`     | No       | HTML template for the print header. Please check this link for details of injecting values [Puppeteer document](https://pptr.dev/#?product=Puppeteer&show=api-pagepdfoptions)      |
+| `--footerTemplate`     | No       | HTML template for the print footer. Please check this link for details of injecting values [Puppeteer document](https://pptr.dev/#?product=Puppeteer&show=api-pagepdfoptions)      |
+|                        |          |                                                                                                                                                                                    |
 
 ## 🎨 Examples and Demo PDF
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,6 +47,8 @@ program
   .option('--disableTOC', 'disable table of contents')
   .option('--coverSub <subtitle>', 'subtitle for PDF cover')
   .option('--waitForRender <timeout>', 'wait for document render')
+  .option('--headerTemplate <html>', 'html template for page header')
+  .option('--footerTemplate <html>', 'html template for page footer')
   .action((options: generatePDFOptions) => {
     generatePDF(options)
       .then(() => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,6 +18,8 @@ export interface generatePDFOptions {
   disableTOC: boolean;
   coverSub: string;
   waitForRender: number;
+  headerTemplate: string;
+  footerTemplate: string;
 }
 
 export async function generatePDF({
@@ -36,6 +38,8 @@ export async function generatePDF({
   disableTOC,
   coverSub,
   waitForRender,
+  headerTemplate,
+  footerTemplate,
 }: generatePDFOptions): Promise<void> {
   const browser = await puppeteer.launch({ args: puppeteerArgs });
   const page = await browser.newPage();
@@ -183,6 +187,9 @@ export async function generatePDF({
     format: pdfFormat,
     printBackground: true,
     margin: pdfMargin,
+    displayHeaderFooter: !!(headerTemplate || footerTemplate),
+    headerTemplate,
+    footerTemplate,
   });
 }
 


### PR DESCRIPTION
Hi, this is a really useful tool but I wanted page numbers so I have added pass through arguments for the puppeteer headers/footers. Let me know if I missed anything.