### PR TITLE
Support Docusaurus 2.4.1 version to generate PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,20 @@ npx mr-pdf --initialDocURLs="https://docusaurus.io/docs/en/installation" --pagin
 npx mr-pdf --initialDocURLs="https://docusaurus.io/docs/" --contentSelector="article" --paginationSelector=".pagination-nav__item--next > a" --excludeSelectors=".margin-vert--xl a" --coverImage="https://docusaurus.io/img/docusaurus.png" --coverTitle="Docusaurus v2"
 ```
 
+### Docusaurus 2.4.1
+
+<https://docusaurus.io/>
+
+`initialDocURLs`: <https://docusaurus.io/docs>
+
+`demoPDF`: <https://github.com/kohheepeace/mr-pdf/blob/master/v241-docusaurus.pdf>
+
+`command`:
+
+```shell
+npx mr-pdf --initialDocURLs="https://docusaurus.io/docs" --contentSelector="article" --paginationSelector=".pagination-nav__link--next" --coverImage="https://docusaurus.io/img/docusaurus.png" --coverTitle="Docusaurus v2.4.1"
+```
+
 ### Vuepress v1
 
 <https://vuepress.vuejs.org/>

--- a/README.md
+++ b/README.md
@@ -51,23 +51,9 @@ npx mr-pdf --initialDocURLs="https://v1.docusaurus.io/docs/en/installation" --pa
 npx mr-pdf --initialDocURLs="https://docusaurus.io/docs/en/installation" --paginationSelector=".docs-prevnext > a.docs-next" --excludeSelectors=".fixedHeaderContainer,footer.nav-footer,#docsNav,nav.onPageNav,a.edit-page-link,div.docs-prevnext" --cssStyle=".navPusher {padding-top: 0;}" --pdfMargin="20"
 ```
 
-### Docusaurus v2 beta
+### Docusaurus 2.4.1
 
 ![20210603060438](https://user-images.githubusercontent.com/29557494/120552058-b4299e00-c431-11eb-833e-1ac1338b0a70.gif)
-
-<https://docusaurus.io/>
-
-`initialDocURLs`: <https://docusaurus.io/docs>
-
-`demoPDF`: <https://github.com/kohheepeace/mr-pdf/blob/master/v2-docusaurus.pdf>
-
-`command`:
-
-```shell
-npx mr-pdf --initialDocURLs="https://docusaurus.io/docs/" --contentSelector="article" --paginationSelector=".pagination-nav__item--next > a" --excludeSelectors=".margin-vert--xl a" --coverImage="https://docusaurus.io/img/docusaurus.png" --coverTitle="Docusaurus v2"
-```
-
-### Docusaurus 2.4.1
 
 <https://docusaurus.io/>
 


### PR DESCRIPTION
Hi,

This PR is raised to fix the issue in generating the PDF with Docusaurus v2.

- Command to generate PDF for **Docusaurus 2.4.1** is updated in README file
- **Docusaurus v2 beta** is no longer supported, hence removed in README file
- Sample [v241-docusaurus.pdf](https://github.com/kohheepeace/mr-pdf/compare/master...sunilg27:mr-pdf:master?expand=1#diff-25c08f9e417393bbffed01145d364ef1414e30a35cef83b6a694a5f2f2308a30) is also added to repository

Please feel free to make changes if necessary.

